### PR TITLE
replace net_mig with migrants

### DIFF
--- a/R/init_rc.R
+++ b/R/init_rc.R
@@ -5,22 +5,23 @@
 #' an additional input into 'Stan'.
 #'
 #' @param ages numeric. A vector of integers for ages.
-#' @param net_mig numeric. A vector of integers for observed age-specific net migrants.
+#' @param migrants numeric. A vector of integers for observed age-specific migrants.
 #' @param pop numeric. A vector of integers for age-specific population.
 #' @param pre_working_age logical (TRUE/FALSE). Whether or not you are including pre working age component.
 #' @param working_age logical (TRUE/FALSE). Whether or not you are including working age component.
 #' @param retirement logical (TRUE/FALSE). Whether or not you are including retirement age component.
 #' @param post_retirement logical (TRUE/FALSE). Whether or not you are including post retirement age component.
 #' @param nchains numeric. A positive integer specifying the number of Markov chains. Should be 4 unless changed otherwise.
+#' @param net_mig numeric. Deprecated argument, use migrants instead.
 #' @importFrom stats runif
 #' @return A list of length \code{nchains}. Each element of the list is a list of numeric values.
 #' Within the inner lists, there is one element for every model parameter.
 #' @export
 #'
 #' @examples
-#' # define ages, net migrants, and population
+#' # define ages, migrants, and population
 #'ages <- 0:80
-#'net_mig <- c(202,215,167,188,206,189,164,
+#'migrants <- c(202,215,167,188,206,189,164,
 #'             158,197,185,176,173,167,198,
 #'             203,237,249,274,319,345,487,
 #'             491,521,505,529,527,521,529,
@@ -50,12 +51,35 @@
 #'         59556,59556,59556,59556,59556)
 #'
 #'#compute initial values
-#'iv <- init_rc(ages, net_mig, pop, pre_working_age=TRUE,
+#'iv <- init_rc(ages, migrants, pop, pre_working_age=TRUE,
 #'              working_age=TRUE, retirement=TRUE, post_retirement=TRUE)
 #'
 
-init_rc <- function(ages, net_mig, pop, pre_working_age, working_age, retirement, post_retirement, nchains=4){
-  rate <- net_mig / pop
+init_rc <- function(ages,
+                    migrants,
+                    pop,
+                    pre_working_age,
+                    working_age,
+                    retirement,
+                    post_retirement,
+                    nchains=4,
+                    net_mig
+                    ){
+
+  # initial checks
+  stopifnot(any(pre_working_age, working_age, retirement, post_retirement))
+  if(!missing(net_mig)) stop("Argument net_mig deprecated, use migrants instead.")
+
+  if(missing(ages)) stop("ages is missing")
+  if(missing(migrants)) stop("migrants is missing")
+  if(missing(pop)) stop("pop is missing")
+
+  if(length(ages)!=length(migrants) | length(migrants)!=length(pop))
+    stop("length of arguments ages, migrants and pop must be equal")
+  if ( !all(migrants == floor(migrants)) ) stop("migrants must comprise of integers")
+  if (sum(migrants > pop)>0) stop("must have migrants <= pop")
+
+  rate <- migrants / pop
   rate_ranked <- order(rate, decreasing=T)
   rate_ranked_by_age <- ages[rate_ranked]
 

--- a/inst/stan/rcmodel.stan
+++ b/inst/stan/rcmodel.stan
@@ -5,7 +5,7 @@ data {
   int<lower=0,upper=1> post_retirement;         // 0 = no, 1 = yes
   int<lower=0> N;
   vector[N] x;                                  //ages
-  int<lower=0> y[N];                            //age-specific net migrants
+  int<lower=0> y[N];                            //age-specific migrants
   vector[N] pop;                                //age-specific population size
 }
 parameters {

--- a/man/init_rc.Rd
+++ b/man/init_rc.Rd
@@ -6,19 +6,20 @@
 \usage{
 init_rc(
   ages,
-  net_mig,
+  migrants,
   pop,
   pre_working_age,
   working_age,
   retirement,
   post_retirement,
-  nchains = 4
+  nchains = 4,
+  net_mig
 )
 }
 \arguments{
 \item{ages}{numeric. A vector of integers for ages.}
 
-\item{net_mig}{numeric. A vector of integers for observed age-specific net migrants.}
+\item{migrants}{numeric. A vector of integers for observed age-specific migrants.}
 
 \item{pop}{numeric. A vector of integers for age-specific population.}
 
@@ -31,6 +32,8 @@ init_rc(
 \item{post_retirement}{logical (TRUE/FALSE). Whether or not you are including post retirement age component.}
 
 \item{nchains}{numeric. A positive integer specifying the number of Markov chains. Should be 4 unless changed otherwise.}
+
+\item{net_mig}{numeric. Deprecated argument, use migrants instead.}
 }
 \value{
 A list of length \code{nchains}. Each element of the list is a list of numeric values.
@@ -42,9 +45,9 @@ Provide these initial values to improve convergence of model. Intended to be use
 an additional input into 'Stan'.
 }
 \examples{
-# define ages, net migrants, and population
+# define ages, migrants, and population
 ages <- 0:80
-net_mig <- c(202,215,167,188,206,189,164,
+migrants <- c(202,215,167,188,206,189,164,
             158,197,185,176,173,167,198,
             203,237,249,274,319,345,487,
             491,521,505,529,527,521,529,
@@ -74,7 +77,7 @@ pop <- c(105505,105505,105505,105505,105505,
         59556,59556,59556,59556,59556)
 
 #compute initial values
-iv <- init_rc(ages, net_mig, pop, pre_working_age=TRUE,
+iv <- init_rc(ages, migrants, pop, pre_working_age=TRUE,
              working_age=TRUE, retirement=TRUE, post_retirement=TRUE)
 
 }

--- a/man/mig_estimate_rc.Rd
+++ b/man/mig_estimate_rc.Rd
@@ -6,19 +6,20 @@
 \usage{
 mig_estimate_rc(
   ages,
-  net_mig,
+  migrants,
   pop,
   pre_working_age,
   working_age,
   retirement,
   post_retirement,
+  net_mig,
   ...
 )
 }
 \arguments{
 \item{ages}{numeric. A vector of integers for ages.}
 
-\item{net_mig}{numeric. A vector of integers for observed age-specific net migrants.}
+\item{migrants}{numeric. A vector of integers for observed age-specific migrants.}
 
 \item{pop}{numeric. A vector of integers for age-specific population.}
 
@@ -30,6 +31,8 @@ mig_estimate_rc(
 
 \item{post_retirement}{logical (TRUE/FALSE). Whether or not to include post retirement age component.}
 
+\item{net_mig}{numeric. Deprecated argument, use migrants instead.}
+
 \item{...}{additional inputs to stan, see ?rstan::stan for details.}
 }
 \value{
@@ -38,13 +41,13 @@ The second element, \code{fit_df}, is a data frame that shows the data and estim
 The third element, \code{check_converge}, is a data frame that provides the R-hat values and effective sample sizes.
 }
 \description{
-Given a set of ages and observed age-specific net migrants, estimate the parameters of a Roger-Castro model migration schedule.
+Given a set of ages and observed age-specific migrants, estimate the parameters of a Roger-Castro model migration schedule.
 Choose between a 7, 9, 11 or 13 parameter model.
 }
 \examples{
-# define ages, net migrants, and population
+# define ages, migrants, and population
 ages <- 0:80
-net_mig <- c(202,215,167,188,206,189,164,
+migrants <- c(202,215,167,188,206,189,164,
             158,197,185,176,173,167,198,
             203,237,249,274,319,345,487,
             491,521,505,529,527,521,529,
@@ -75,7 +78,7 @@ pop <- c(105505,105505,105505,105505,105505,
 
 
 # fit the model
-res <- mig_estimate_rc(ages, net_mig, pop,
+res <- mig_estimate_rc(ages, migrants, pop,
                        pre_working_age = TRUE,
                        working_age = TRUE,
                        retirement = TRUE,
@@ -85,7 +88,7 @@ res <- mig_estimate_rc(ages, net_mig, pop,
                        iter = 10, chains = 1 #to speed up example
                        )
 # plot the results and data
-plot(ages, net_mig/pop, ylab = "migration rate", xlab = "age")
+plot(ages, migrants/pop, ylab = "migration rate", xlab = "age")
 lines(ages, res[["fit_df"]]$median, col = "red")
 legend("topright", legend=c("data", "fit"), col=c("black", "red"), lty=1, pch = 1)
 

--- a/vignettes/convergence_issues.Rmd
+++ b/vignettes/convergence_issues.Rmd
@@ -49,15 +49,15 @@ library(tibble)
 library(ggplot2)
 
 ages <- 0:80
-net_mig <- c(11804, 10606, 9845, 9244, 8471, 7940, 7348, 6885, 6431,
-             6055, 5454, 4997, 4845, 4596, 4397, 4814, 4592, 4646, 5386,
-             7180, 11374, 14713, 17195, 18937, 19223, 19091, 18507,
-             17615, 16929, 15693, 15246, 14152, 13365, 12340, 11609,
-             10278, 9547, 8992, 8438, 7883, 7315, 6909, 6730, 6272,
-             5994, 6087, 5896, 5592, 5487, 5237, 6021, 5933, 5577,
-             5674, 5503, 4916, 5008, 4822, 4824, 4696, 4086, 4019,
-             4139, 4054, 4134, 3625, 3871, 4238, 4306, 4440, 3118,
-             2980, 2885, 2845, 2795, 2085, 2076, 2035, 2030, 1986, 2037)
+migrants <- c(11804, 10606, 9845, 9244, 8471, 7940, 7348, 6885, 6431,
+              6055, 5454, 4997, 4845, 4596, 4397, 4814, 4592, 4646, 5386,
+              7180, 11374, 14713, 17195, 18937, 19223, 19091, 18507,
+              17615, 16929, 15693, 15246, 14152, 13365, 12340, 11609,
+              10278, 9547, 8992, 8438, 7883, 7315, 6909, 6730, 6272,
+              5994, 6087, 5896, 5592, 5487, 5237, 6021, 5933, 5577,
+              5674, 5503, 4916, 5008, 4822, 4824, 4696, 4086, 4019,
+              4139, 4054, 4134, 3625, 3871, 4238, 4306, 4440, 3118,
+              2980, 2885, 2845, 2795, 2085, 2076, 2035, 2030, 1986, 2037)
 pop <- c(105505, 105505, 105505, 105505, 105505, 106126, 106126, 106126,
          106126, 106126, 100104, 100104, 100104, 100104, 100104, 114880,
          114880, 114880, 114880, 114880, 136845, 136845, 136845, 136845,
@@ -71,7 +71,7 @@ pop <- c(105505, 105505, 105505, 105505, 105505, 106126, 106126, 106126,
 ```
 ```{r, eval=FALSE}
 rc_res <- mig_estimate_rc(
-  ages, net_mig, pop,
+  ages, migrants, pop,
   pre_working_age = TRUE,
   working_age = TRUE,
   retirement = TRUE,
@@ -105,8 +105,8 @@ rc_res[['check_converge']] <- matrix(
                   c("mean", "se_mean", "n_eff", "Rhat")),
   byrow = TRUE)
 
-rc_res[['fit_df']] <- tibble(age = 0:80,
-       data = net_mig/pop,
+rc_res[['fit_df']] <- tibble(ages = 0:80,
+       data = migrants/pop,
        median = c(0.11107413, 0.10207562, 0.09392648, 0.08667344, 0.08025095, 0.07451119, 
                   0.06935217, 0.06473068, 0.06059616, 0.05690437, 0.05363063, 0.05073012, 
                   0.04815361, 0.04582636, 0.04373611, 0.04189403, 0.04047357, 0.04090839, 
@@ -164,7 +164,7 @@ We see that there are many R-hat values that are very large and thus the model h
 rc_res[["fit_df"]] %>%
   ggplot(aes(ages, data)) +
   geom_point(aes(color = "data")) +
-  geom_line(aes(x = age, y = median, color = "fit")) +
+  geom_line(aes(x = ages, y = median, color = "fit")) +
   geom_ribbon(aes(ymin = lower, ymax = upper), alpha = 0.2) +
   scale_color_manual(name = "", values = c(data = "red", fit = "black")) +
   ylab("migration rate")
@@ -179,7 +179,7 @@ One method for improving convergence is to adjust the Stan parameters. Stan may 
 To adjust Stan parameters, `mig_estimate_rc` can accept additional inputs for Stan. For example, to increase the `max_treedepth`, `adapt_delta`, and number of iterations, you can do the following: 
 
 ```{r, eval=FALSE}
-res <- mig_estimate_rc(ages, net_mig, pop,
+res <- mig_estimate_rc(ages, migrants, pop,
                        pre_working_age = TRUE,
                        working_age = TRUE,
                        retirement = TRUE,
@@ -198,7 +198,7 @@ One of the additional parameters that can be provided to Stan is `init`, which s
 
 ```{r, eval=FALSE}
 init_vals <- init_rc(ages,
-                     net_mig,
+                     migrants,
                      pop,
                      pre_working_age = TRUE,
                      working_age = TRUE,
@@ -206,7 +206,7 @@ init_vals <- init_rc(ages,
                      post_retirement = TRUE,
                      nchains = 4)
 
-res <- mig_estimate_rc(ages, net_mig, pop,
+res <- mig_estimate_rc(ages, migrants, pop,
                        pre_working_age = TRUE,
                        working_age = TRUE,
                        retirement = TRUE,
@@ -228,7 +228,7 @@ Recall the example above of a non-convergent model. We will fix this model by ad
 
 ```{r, eval=FALSE}
 init_vals <- init_rc(ages,
-                     net_mig,
+                     migrants,
                      pop,
                      pre_working_age = TRUE,
                      working_age = TRUE,
@@ -236,7 +236,7 @@ init_vals <- init_rc(ages,
                      post_retirement = TRUE,
                      nchains = 4)
 
-rc_res_fixed <- mig_estimate_rc(ages, net_mig, pop,
+rc_res_fixed <- mig_estimate_rc(ages, migrants, pop,
                        pre_working_age = TRUE,
                        working_age = TRUE,
                        retirement = TRUE,
@@ -272,8 +272,8 @@ rc_res_fixed[['check_converge']] <- matrix(
                   c("mean", "se_mean", "n_eff", "Rhat")),
   byrow = TRUE)
 
-rc_res_fixed[['fit_df']] <- tibble(age = 0:80,
-       data = net_mig/pop,
+rc_res_fixed[['fit_df']] <- tibble(ages = 0:80,
+       data = migrants/pop,
        median = c(0.11066577, 0.10183467, 0.09389724, 0.08677859, 0.08039617, 0.07466633,
                   0.06952911, 0.06491991, 0.06079010, 0.05708701, 0.05377364, 0.05079940, 
                   0.04814050, 0.04576222, 0.04363252, 0.04173797, 0.04023607, 0.04059125, 
@@ -331,7 +331,7 @@ We can now plot and interpret the model results.
 rc_res_fixed[["fit_df"]] %>%
   ggplot(aes(ages, data)) +
   geom_point(aes(color = "data")) +
-  geom_line(aes(x = age, y = median, color = "fit")) +
+  geom_line(aes(x = ages, y = median, color = "fit")) +
   geom_ribbon(aes(ymin = lower, ymax = upper), alpha = 0.2) +
   scale_color_manual(name = "", values = c(data = "red", fit = "black")) +
   ylab("migration rate")

--- a/vignettes/intro_to_rcbayes.Rmd
+++ b/vignettes/intro_to_rcbayes.Rmd
@@ -113,7 +113,7 @@ Note, however, that all parameters within a particular component family must be 
 
 #### Overview
 
-The `mig_estimate_rc` function returns estimated Rogers-Castro parameters and $m(x)$ values, based on observed age-specific net migrants, age-specific population sizes, an age range, and the Rogers-Castro components to be included in the model. The function has the capability of estimating a Rogers-Castro age schedule with any combination of the components `pre_working_age`, `working_age`, `retirement` and `post_retirement`. These are specified as logicals (either `TRUE` or `FALSE`) in the function.
+The `mig_estimate_rc` function returns estimated Rogers-Castro parameters and $m(x)$ values, based on observed age-specific migrants, age-specific population sizes, an age range, and the Rogers-Castro components to be included in the model. The function has the capability of estimating a Rogers-Castro age schedule with any combination of the components `pre_working_age`, `working_age`, `retirement` and `post_retirement`. These are specified as logicals (either `TRUE` or `FALSE`) in the function.
 
 As illustrated above, Rogers-Castro migration age schedules are highly non-linear, as so are not necessarily straight forward to estimate. Previous approaches have used, for example, Excel's Solver function or the `optim` function in `R`.[^1] However, the estimated parameters and schedules are highly sensitive to the initial values chosen for the parameter values, and convergence is difficult to achieve for the 11 and 13 parameter models.
 
@@ -131,10 +131,10 @@ set.seed(123)
 
 ```{r}
 ages <- 0:80
-net_mig <- c(49, 48, 48, 52, 50, 45, 42, 46, 45, 44, 47, 55, 57, 59, 67, 69, 71, 78, 93, 88, 116,
-             106, 102, 104, 102, 123, 112, 102, 112, 105, 100, 83, 81, 77, 78, 77, 66, 64, 65, 64,
-             68, 52, 59, 51, 54, 55, 52, 58, 64, 53, 68, 53, 57, 67, 71, 78, 75, 77, 77, 83, 88,
-             80, 84, 79, 77, 83, 71, 59, 65, 67, 64, 63, 56, 50, 43, 46, 46, 38, 32, 28, 29)
+migrants <- c(49, 48, 48, 52, 50, 45, 42, 46, 45, 44, 47, 55, 57, 59, 67, 69, 71, 78, 93, 88, 116,
+              106, 102, 104, 102, 123, 112, 102, 112, 105, 100, 83, 81, 77, 78, 77, 66, 64, 65, 64,
+              68, 52, 59, 51, 54, 55, 52, 58, 64, 53, 68, 53, 57, 67, 71, 78, 75, 77, 77, 83, 88,
+              80, 84, 79, 77, 83, 71, 59, 65, 67, 64, 63, 56, 50, 43, 46, 46, 38, 32, 28, 29)
 pop <- c(2028, 2193, 2271, 2370, 2403, 2160, 2109, 2206, 2456, 2334, 2392, 2534, 2542, 2601, 2526,
          2416, 2420, 2344, 2606, 2355, 2867, 2589, 2426, 2390, 2377, 2909, 2753, 2633, 2847, 2819,
          2979, 2608, 2708, 2602, 2745, 2883, 2624, 2607, 2677, 2637, 2964, 2414, 2481, 2464, 2510,
@@ -142,7 +142,7 @@ pop <- c(2028, 2193, 2271, 2370, 2403, 2160, 2109, 2206, 2456, 2334, 2392, 2534,
          2970, 2882, 2839, 2737, 2782, 2799, 2710, 2527, 2512, 2530, 2505, 2521, 2551, 2125, 1838,
          2057, 2037, 1804, 1542, 1470, 1452)
 
-df <- tibble(age = ages, mx = net_mig / pop)
+df <- tibble(age = ages, mx = migrants / pop)
 df %>%
   ggplot(aes(age, mx)) +
   geom_point() +
@@ -154,7 +154,7 @@ Let's fit a Rogers-Castro migration age schedule to these data. Below, we choose
 
 ```{r, eval=FALSE}
 rc_res <- mig_estimate_rc(
-  ages, net_mig, pop,
+  ages, migrants, pop,
   pre_working_age = TRUE,
   working_age = TRUE,
   retirement = TRUE,
@@ -208,8 +208,8 @@ rc_res[['pars_df']] <- tibble(variable = c("a1","a2","a3","alpha1","alpha2","alp
        upper = c(0.01106290,  0.06797684,  0.02883773,  2.25796406,  0.23777804,  0.35320899,  0.02185859,
                  0.16919224,  0.19132286, 26.91274982, 66.84958398))
 
-rc_res[['fit_df']] <- tibble(age = 0:80,
-       data = net_mig/pop,
+rc_res[['fit_df']] <- tibble(ages = 0:80,
+       data = migrants/pop,
        median = c(0.02445917, 0.02212957, 0.02123731, 0.02083668, 0.02063243, 0.02050311, 0.02042182, 
                   0.02038452, 0.02039545, 0.02048247, 0.02069491, 0.02113354, 0.02188968, 0.02309565, 
                   0.02488725, 0.02723605, 0.03001204, 0.03295246, 0.03584502, 0.03844924, 0.04053613, 
@@ -288,7 +288,7 @@ We can plot the observed data and estimated fit using the `fit_df` object:
 rc_res[["fit_df"]] %>%
   ggplot(aes(ages, data)) +
   geom_point(aes(color = "data")) +
-  geom_line(aes(x = age, y = median, color = "fit")) +
+  geom_line(aes(x = ages, y = median, color = "fit")) +
   geom_ribbon(aes(ymin = lower, ymax = upper), alpha = 0.2) +
   scale_color_manual(name = "", values = c(data = "red", fit = "black")) +
   ylab("migration rate")


### PR DESCRIPTION
The functions mig_estimate_rc and init_rc originally had arguments called net_mig (which stood for net migrants). This naming was incorrect, it has now changed to migrants. 

If the user uses argument called net_mig, there will be an error message telling the user to use migrants instead. 